### PR TITLE
feat(dns)!: create route53 subdomain [TWO-622]

### DIFF
--- a/argoflow-aws-infrastructure-wrapper.tf
+++ b/argoflow-aws-infrastructure-wrapper.tf
@@ -13,6 +13,6 @@ module "argoflow_aws_infrastructure" {
   cluster_autoscaler_kubernetes_service_account_namespace = var.cluster_autoscaler_kubernetes_service_account_namespace
   eks_cluster_name                                        = var.eks_cluster_name
   kubeflow_cluster_oidc_provider_arn                      = var.kubeflow_cluster_oidc_provider_arn
-  kubeflow_route53_hosted_zone_id                         = var.kubeflow_route53_hosted_zone_id
+  route53_subdomain                                       = var.route53_subdomain
   stage                                                   = var.stage
 }

--- a/inputs.tf
+++ b/inputs.tf
@@ -66,8 +66,9 @@ variable "kubeflow_cluster_oidc_provider_arn" {
   description = "The OIDC provider ARN of the Kubeflow Kubernetes cluster"
 }
 
-variable "kubeflow_route53_hosted_zone_id" {
-  description = "The AWS Route 53 Hosted Zone ID to be used for URLs for this Kubeflow instance"
+variable "route53_subdomain" {
+  type        = string
+  description = "The subdomain to create in Route53 for this argoflow-aws instance"
 }
 
 variable "stage" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -98,3 +98,18 @@ output "kubeflow_pipelines_user_credentials_secret_access_key" {
   sensitive   = true
   value       = module.argoflow_aws_infrastructure.kubeflow_pipelines_user_credentials_secret_access_key
 }
+
+output "kubeflow_route53_zoneid" {
+  description = "The Zone ID of the AWS Route 53 zone created for this Kubeflow instance"
+  value       = module.argoflow_aws_infrastructure.kubeflow_route53_zone_id
+}
+
+output "kubeflow_route53_zone_name" {
+  description = "The name of the AWS Route 53 zone created for this Kubeflow instance"
+  value       = module.argoflow_aws_infrastructure.kubeflow_route53_zone_name
+}
+
+output "kubeflow_route53_zone_nameservers" {
+  description = "The nameservers of the AWS Route 53 zone created for this Kubeflow instance"
+  value       = module.argoflow_aws_infrastructure.kubeflow_route53_zone_nameservers
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -82,6 +82,7 @@ No modules.
 | [aws_iam_user.kubeflow_pipelines_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy.kubeflow_pipelines_user_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_kms_key.kubeflow_secrets_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_route53_zone.argoflow_aws_subdomain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_s3_bucket.kubeflow_mlflow_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.kubeflow_pipelines_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_public_access_block.kubeflow_mlflow_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
@@ -118,9 +119,9 @@ No modules.
 | <a name="input_cluster_autoscaler_kubernetes_service_account_namespace"></a> [cluster\_autoscaler\_kubernetes\_service\_account\_namespace](#input\_cluster\_autoscaler\_kubernetes\_service\_account\_namespace) | The Kubernetes Namespace in which the cluster-autoscaler Service Account is located | `string` | `"kube-system"` | no |
 | <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | The name of the EKS (Elastic Kubernetes Service) cluster. | `string` | n/a | yes |
 | <a name="input_external_secret_names"></a> [external\_secret\_names](#input\_external\_secret\_names) | The secrets that need to be created in AWS Secrets Manager | `list(string)` | <pre>[<br>  "argocd/https_username",<br>  "argocd/https_password",<br>  "auth/client_id",<br>  "auth/client_secret",<br>  "auth/cookie_secret",<br>  "istio-system/auth_ca_cert",<br>  "istio-system/auth_cert",<br>  "istio-system/auth_cert_pk",<br>  "istio-system/gateway_ca_cert",<br>  "istio-system/gateway_cert",<br>  "istio-system/gateway_cert_pk",<br>  "istio-system/monitoring_ca_cert",<br>  "istio-system/monitoring_cert",<br>  "istio-system/monitoring_cert_pk",<br>  "kubeflow/rds_username",<br>  "kubeflow/rds_password",<br>  "kubeflow/s3_accesskey",<br>  "kubeflow/s3_secretkey",<br>  "mlflow/rds_username",<br>  "mlflow/rds_password"<br>]</pre> | no |
-| <a name="input_kubeflow_cluster_oidc_provider_arn"></a> [kubeflow\_cluster\_oidc\_provider\_arn](#input\_kubeflow\_cluster\_oidc\_provider\_arn) | The OIDC provider ARN of the Kubeflow Kubernetes cluster | `any` | n/a | yes |
-| <a name="input_kubeflow_route53_hosted_zone_id"></a> [kubeflow\_route53\_hosted\_zone\_id](#input\_kubeflow\_route53\_hosted\_zone\_id) | The AWS Route 53 Hosted Zone ID to be used for URLs for this Kubeflow instance | `any` | n/a | yes |
-| <a name="input_stage"></a> [stage](#input\_stage) | The stage (environment) of the build - usually one of [test, dev, qa, prod] | `any` | n/a | yes |
+| <a name="input_kubeflow_cluster_oidc_provider_arn"></a> [kubeflow\_cluster\_oidc\_provider\_arn](#input\_kubeflow\_cluster\_oidc\_provider\_arn) | The OIDC provider ARN of the Kubeflow Kubernetes cluster | `string` | n/a | yes |
+| <a name="input_route53_subdomain"></a> [route53\_subdomain](#input\_route53\_subdomain) | The subdomain to create in Route53 for this argoflow-aws instance | `string` | n/a | yes |
+| <a name="input_stage"></a> [stage](#input\_stage) | The stage (environment) of the build - usually one of [test, dev, qa, prod] | `string` | n/a | yes |
 
 ## Outputs
 
@@ -145,4 +146,7 @@ No modules.
 | <a name="output_kubeflow_pipelines_user_credentials_secret_access_key"></a> [kubeflow\_pipelines\_user\_credentials\_secret\_access\_key](#output\_kubeflow\_pipelines\_user\_credentials\_secret\_access\_key) | The secret access key for the AWS IAM user with permissions to the Kubeflow Pipelines S3 bucket |
 | <a name="output_kubeflow_rds_host"></a> [kubeflow\_rds\_host](#output\_kubeflow\_rds\_host) | The hostname of the Kubeflow RDS instance |
 | <a name="output_kubeflow_redis_oidc_cache_nodes"></a> [kubeflow\_redis\_oidc\_cache\_nodes](#output\_kubeflow\_redis\_oidc\_cache\_nodes) | The nodes of the Kubeflow redis cache to be used for OIDC |
+| <a name="output_kubeflow_route53_zone_id"></a> [kubeflow\_route53\_zone\_id](#output\_kubeflow\_route53\_zone\_id) | The ID of the AWS Route 53 zone created for this Kubeflow instance |
+| <a name="output_kubeflow_route53_zone_name"></a> [kubeflow\_route53\_zone\_name](#output\_kubeflow\_route53\_zone\_name) | The name of the AWS Route 53 zone created for this Kubeflow instance |
+| <a name="output_kubeflow_route53_zone_nameservers"></a> [kubeflow\_route53\_zone\_nameservers](#output\_kubeflow\_route53\_zone\_nameservers) | The nameservers of the AWS Route 53 zone created for this Kubeflow instance |
 | <a name="output_secretsmanager_secrets"></a> [secretsmanager\_secrets](#output\_secretsmanager\_secrets) | The AWS Secrets Manager secrets created for Kubeflow |

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,0 +1,8 @@
+resource "aws_route53_zone" "argoflow_aws_subdomain" {
+  name = var.route53_subdomain
+
+  tags = {
+    Terraform = "true"
+    Stage     = var.stage
+  }
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -140,7 +140,7 @@ data "aws_iam_policy_document" "external_dns_infrastructure_access_policy_docume
       "route53:ChangeResourceRecordSets"
     ]
     effect    = "Allow"
-    resources = ["arn:aws:route53:::hostedzone/${var.kubeflow_route53_hosted_zone_id}"]
+    resources = ["arn:aws:route53:::hostedzone/${aws_route53_zone.argoflow_aws_subdomain.zone_id}"]
   }
 
   statement {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -258,6 +258,15 @@ data "aws_iam_policy_document" "external_secrets_infrastructure_access_policy_do
     effect    = "Allow"
     resources = ["arn:aws:secretsmanager:ap-southeast-1:${var.aws_secretsmanager_account_id}:secret:kubeflow*"]
   }
+
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:kms:us-east-1:${var.aws_secretsmanager_account_id}:key/${aws_kms_key.kubeflow_secrets_key.id}"]
+  }
 }
 
 resource "aws_iam_policy" "external_secrets_policy" {

--- a/terraform/inputs.tf
+++ b/terraform/inputs.tf
@@ -44,17 +44,17 @@ variable "aws_vpc_public_subnets" {
   description = "A list of the public VPC subnet IDs used by the Kubeflow EKS cluster"
 }
 
-
-
 # Kubernetes Cluster Autoscaler: https://github.com/kubernetes/autoscaler
 # Cluster Autoscaler YAML: https://raw.githubusercontent.com/kubernetes/autoscaler/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
 
 variable "cluster_autoscaler_kubernetes_service_account_name" {
+  type        = string
   description = "The Kubernetes Service Account used by the cluster-autoscaler pod"
   default     = "cluster-autoscaler"
 }
 
 variable "cluster_autoscaler_kubernetes_service_account_namespace" {
+  type        = string
   description = "The Kubernetes Namespace in which the cluster-autoscaler Service Account is located"
   default     = "kube-system"
 }
@@ -65,13 +65,16 @@ variable "eks_cluster_name" {
 }
 
 variable "kubeflow_cluster_oidc_provider_arn" {
+  type        = string
   description = "The OIDC provider ARN of the Kubeflow Kubernetes cluster"
 }
 
-variable "kubeflow_route53_hosted_zone_id" {
-  description = "The AWS Route 53 Hosted Zone ID to be used for URLs for this Kubeflow instance"
+variable "route53_subdomain" {
+  type        = string
+  description = "The subdomain to create in Route53 for this argoflow-aws instance"
 }
 
 variable "stage" {
+  type        = string
   description = "The stage (environment) of the build - usually one of [test, dev, qa, prod]"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -80,7 +80,7 @@ output "kubeflow_redis_oidc_cache_nodes" {
 
 output "secretsmanager_secrets" {
   description = "The AWS Secrets Manager secrets created for Kubeflow"
-  value       = ["${aws_secretsmanager_secret.kubeflow_secret.*.id}"]
+  value       = ["${aws_secretsmanager_secret.kubeflow_secret.*.name}"]
 }
 
 output "kubeflow_pipelines_aws_iam_username" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -98,3 +98,18 @@ output "kubeflow_pipelines_user_credentials_secret_access_key" {
   sensitive   = true
   value       = aws_iam_access_key.kubeflow_pipelines_user_credentials.secret
 }
+
+output "kubeflow_route53_zone_id" {
+  description = "The ID of the AWS Route 53 zone created for this Kubeflow instance"
+  value       = aws_route53_zone.argoflow_aws_subdomain.zone_id
+}
+
+output "kubeflow_route53_zone_name" {
+  description = "The name of the AWS Route 53 zone created for this Kubeflow instance"
+  value       = aws_route53_zone.argoflow_aws_subdomain.name
+}
+
+output "kubeflow_route53_zone_nameservers" {
+  description = "The nameservers of the AWS Route 53 zone created for this Kubeflow instance"
+  value       = aws_route53_zone.argoflow_aws_subdomain.name_servers
+}


### PR DESCRIPTION

<!--
* Please link to at least one issue in the issue tracker. If an issue doesn't exist,
  create one.
* PR titles should follow https://www.conventionalcommits.org.
-->

### Info Required for All Commits

Description:

* Fixes the module outputs to provide the Secret names of AWS Secrets Manager secrets (instead of ARNs)
* BREAKING CHANGE: This commit adds support for creating a Route53 hosted zone subdomain, which means new/changed input variables which represent a breaking change. Consuming modules will have to update their input variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/argoflow-aws-infrastructure/6)
<!-- Reviewable:end -->
